### PR TITLE
Fix collisionManager initialization error

### DIFF
--- a/game.js
+++ b/game.js
@@ -59,7 +59,7 @@ window.onload = function() {
             groundTiles.push(new Ground(i * 64, canvas.height - groundHeight - 64, '3,1', groundImage));
         }
 
-        collisionManager = new CollisionManager(player, obstacles, assets); // Initialize collisionManager inside the init function
+        collisionManager = new CollisionManager(player, obstacles, groundTiles, assets); // Initialize collisionManager inside the init function
     }
 
     function handleInput() {


### PR DESCRIPTION
Initialize `collisionManager` with `groundTiles` parameter in `init` function.

* Modify `collisionManager` initialization to include `groundTiles` parameter in `init` function

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bartbender/jump-g/pull/4?shareId=9514f598-c8ce-4939-bc56-1abbece5fb8d).