### PR TITLE
Fix collisionManager is not defined error

### DIFF
--- a/game.js
+++ b/game.js
@@ -44,6 +44,8 @@ window.onload = function() {
     });
 
     // Game functions
+    let collisionManager; // Define collisionManager variable outside the callback function
+
     function init() {
         player = new Player(playerMargin, canvas.height - groundHeight - 50 - 64, playerImage, canvas); // Ajustar la posición inicial del jugador
         obstacles = [];
@@ -57,6 +59,7 @@ window.onload = function() {
             groundTiles.push(new Ground(i * 64, canvas.height - groundHeight - 64, '3,1', groundImage));
         }
 
+        collisionManager = new CollisionManager(player, obstacles, assets); // Initialize collisionManager variable in the init function
         collisionManager.initialize();
     }
 
@@ -153,7 +156,6 @@ window.onload = function() {
             powerUp: 'powerUp.wav'
         }, function() {
             init();
-            const collisionManager = new CollisionManager(player, obstacles, assets);
             gameLoop();
         });
     });


### PR DESCRIPTION
Define the `collisionManager` variable outside the callback function in `game.js`.

* Initialize the `collisionManager` variable in the `init` function.
* Remove the initialization of `collisionManager` from the callback function of `assets.loadSounds`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bartbender/jump-g/pull/6?shareId=0cbb4d7f-2946-43a8-9f52-d4dc4195c4dc).